### PR TITLE
MatchMaker: search for strings that equal rather than contain factorName

### DIFF
--- a/src/main/java/org/pankratzlab/internal/gwas/MatchMaker.java
+++ b/src/main/java/org/pankratzlab/internal/gwas/MatchMaker.java
@@ -195,7 +195,7 @@ public class MatchMaker {
       String[] header = origSamplesFile.readLine().trim().split(PSF.Regex.GREEDY_WHITESPACE);
       for (int i = 0; i < numericFactorNames.size(); i++) {
         for (int j = 0; j < header.length; j++) {
-          if (header[j].contains(numericFactorNames.get(i))) {
+          if (header[j].equals(numericFactorNames.get(i))) {
             columnsToUse.put(j, doubleLoadings.get(i));
           }
         }


### PR DESCRIPTION
Not positive if we want this, but this might avoid an issue I came across -  I was specifying "bmi_baseline_1 " as a desired factor and was getting  "unit_bmi_baseline_1" returned instead from columns that contained entries like `bmi_baseline_1`, `age_at_bmi_baseline_1`, and `unit_bmi_baseline_1` 

